### PR TITLE
Refactor modules to be more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ webhook_broker_access_log_path   = "path-prefix"
 webhook_broker_hostname          = "match-hostname-to-certificate"
 webhook_broker_log_bucket        = "cluster-log-bucket"
 webhook_broker_log_path          = "cluster/path/prefix"
+map_roles = [
+    {
+      rolearn  = "arn:aws:iam::<ACCOUNT_NUMBER>:role/<ROLE_NAME>"
+      username = "<ROLE_NAME>"
+      groups   = ["system:masters"]
+    }
+  ]
+map_users = [
+    {
+      userarn  = "arn:aws:iam::<ACCOUNT_NUMBER>:user/<USER_NAME>"
+      username = "<USER_NAME>"
+      groups   = ["system:masters"]
+    }
+  ]
 ```
 
 The `kubernetes-dashboard` ingress controller is disabled by default as we are deploying the cluster in public subnet; please consider enabling it when deploying in a private subnet by passing [Helm Chart values](https://artifacthub.io/packages/helm/k8s-dashboard/kubernetes-dashboard).

--- a/main.tf
+++ b/main.tf
@@ -96,20 +96,8 @@ module "eks" {
   vpc_id                          = module.vpc.vpc_id
   cluster_endpoint_private_access = false
   cluster_endpoint_public_access  = true
-  map_users = [
-    {
-      userarn  = "arn:aws:iam::<ACCOUNT_NUMBER>:user/<USER_NAME>"
-      username = "<USER_NAME>"
-      groups   = ["system:masters"]
-    }
-  ]
-  map_roles = [
-    {
-      rolearn  = "arn:aws:iam::<ACCOUNT_NUMBER>:role/<ROLE_NAME>"
-      username = "<ROLE_NAME>"
-      groups   = ["system:masters"]
-    },
-  ]
+  map_users                       = var.map_users
+  map_roles                       = var.map_roles
 }
 
 # RDS

--- a/modules/kubernetes-goodies/conf/cluster-autoscaler-chart-values.yml
+++ b/modules/kubernetes-goodies/conf/cluster-autoscaler-chart-values.yml
@@ -11,5 +11,5 @@ rbac:
       eks.amazonaws.com/role-arn: ${role_arn}
 
 autoDiscovery:
-  clusterName: test-eks-w7b6
+  clusterName: ${cluster_name}
   enabled: true

--- a/modules/kubernetes-goodies/main.tf
+++ b/modules/kubernetes-goodies/main.tf
@@ -82,8 +82,8 @@ resource "kubernetes_cluster_role_binding" "cluster-admin-binding" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = local.k8s_dashboard_service_account_name
-    namespace = local.k8s_dashboard_namespace
+    name      = local.k8s_dashboard_namespace
+    namespace = local.k8s_service_account_namespace
   }
 }
 
@@ -105,7 +105,7 @@ resource "helm_release" "cluster-autoscaler" {
   depends_on = [module.iam_assumable_role_admin]
 
   values = [
-    templatefile("${path.module}/conf/cluster-autoscaler-chart-values.yml", { role_arn = module.iam_assumable_role_admin.this_iam_role_arn })
+    templatefile("${path.module}/conf/cluster-autoscaler-chart-values.yml", { role_arn = module.iam_assumable_role_admin.this_iam_role_arn, cluster_name = var.cluster_name })
   ]
 }
 

--- a/modules/kubernetes-goodies/main.tf
+++ b/modules/kubernetes-goodies/main.tf
@@ -82,8 +82,8 @@ resource "kubernetes_cluster_role_binding" "cluster-admin-binding" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = local.k8s_dashboard_namespace
-    namespace = local.k8s_service_account_namespace
+    name      = local.k8s_dashboard_service_account_name
+    namespace = local.k8s_dashboard_namespace
   }
 }
 

--- a/modules/simple-kubernetes/main.tf
+++ b/modules/simple-kubernetes/main.tf
@@ -39,7 +39,7 @@ module "eks" {
 
   worker_groups = [
     {
-      name                 = "worker-group-1"
+      name                 = "${var.cluster_name}-worker-group-1"
       asg_desired_capacity = var.on_demand_desired_capacity
       asg_min_size         = var.on_demand_min_size
       asg_max_size         = var.on_demand_max_size
@@ -48,7 +48,7 @@ module "eks" {
       tags                 = local.asg_tags
     },
     {
-      name                     = "worker-spot-group-1"
+      name                     = "${var.cluster_name}-worker-spot-group-1"
       asg_desired_capacity     = var.spot_desired_capacity
       asg_max_size             = var.spot_max_size
       kubelet_extra_args       = "--node-labels=node.kubernetes.io/lifecycle=spot"

--- a/modules/simple-kubernetes/main.tf
+++ b/modules/simple-kubernetes/main.tf
@@ -9,58 +9,55 @@ terraform {
   }
 }
 
+locals {
+  asg_tags = [
+    {
+      "key"                 = "k8s.io/cluster-autoscaler/enabled"
+      "propagate_at_launch" = "false"
+      "value"               = "true"
+    },
+    {
+      "key"                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
+      "propagate_at_launch" = "false"
+      "value"               = "true"
+    }
+  ]
+}
+
 module "eks" {
-  source          = "terraform-aws-modules/eks/aws"
-  version         = "13.2.1"
-  cluster_name    = var.cluster_name
-  cluster_version = var.k8s_version
-  subnets         = var.subnets
-  vpc_id          = var.vpc_id
-  enable_irsa     = true
+  source                          = "terraform-aws-modules/eks/aws"
+  version                         = "13.2.1"
+  cluster_name                    = var.cluster_name
+  cluster_version                 = var.k8s_version
+  subnets                         = var.subnets
+  vpc_id                          = var.vpc_id
+  enable_irsa                     = true
+  cluster_endpoint_private_access = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access  = var.cluster_endpoint_public_access
+  map_users                       = var.map_users
+  map_roles                       = var.map_roles
 
   worker_groups = [
     {
-      name                 = "${var.cluster_name}-worker-group-1"
-      asg_desired_capacity = "1"
-      asg_min_size         = "1"
+      name                 = "worker-group-1"
+      asg_desired_capacity = var.on_demand_desired_capacity
+      asg_min_size         = var.on_demand_min_size
       asg_max_size         = var.on_demand_max_size
       instance_type        = var.on_demand_instance_type
       ami_id               = var.linux_ami
-      tags = [
-        {
-          "key"                 = "k8s.io/cluster-autoscaler/enabled"
-          "propagate_at_launch" = "false"
-          "value"               = "true"
-        },
-        {
-          "key"                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
-          "propagate_at_launch" = "false"
-          "value"               = "true"
-        }
-      ]
+      tags                 = local.asg_tags
     },
     {
-      name                     = "${var.cluster_name}-worker-spot-group-1"
-      asg_desired_capacity     = "2"
-      asg_max_size             = "100"
+      name                     = "worker-spot-group-1"
+      asg_desired_capacity     = var.spot_desired_capacity
+      asg_max_size             = var.spot_max_size
       kubelet_extra_args       = "--node-labels=node.kubernetes.io/lifecycle=spot"
       instance_type            = var.spot_instance_type
       ami_id                   = var.linux_ami
-      spot_instance_pools      = 2
+      spot_instance_pools      = var.spot_instance_pools
       spot_allocation_strategy = "lowest-price" # Valid options are 'lowest-price' and 'capacity-optimized'. If 'lowest-price', the Auto Scaling group launches instances using the Spot pools with the lowest price, and evenly allocates your instances across the number of Spot pools. If 'capacity-optimized', the Auto Scaling group launches instances using Spot pools that are optimally chosen based on the available Spot capacity.
       spot_price               = var.spot_max_price
-      tags = [
-        {
-          "key"                 = "k8s.io/cluster-autoscaler/enabled"
-          "propagate_at_launch" = "false"
-          "value"               = "true"
-        },
-        {
-          "key"                 = "k8s.io/cluster-autoscaler/${var.cluster_name}"
-          "propagate_at_launch" = "false"
-          "value"               = "true"
-        }
-      ]
+      tags                     = local.asg_tags
     }
   ]
 }

--- a/modules/simple-kubernetes/variables.tf
+++ b/modules/simple-kubernetes/variables.tf
@@ -8,6 +8,11 @@ variable "cluster_name" {
   description = "AWS Region"
 }
 
+variable "k8s_version" {
+  default     = "1.18"
+  description = "EKS k8s version"
+}
+
 variable "subnets" {
   description = "Subnets to create the Kubernetes cluster in"
 }
@@ -16,9 +21,19 @@ variable "vpc_id" {
   description = "VPC ID to create the Kubernetes cluster in"
 }
 
-variable "k8s_version" {
-  default     = "1.18"
-  description = "EKS k8s version"
+variable "on_demand_desired_capacity" {
+  default     = 1
+  description = "On Demand Desired capacity"
+}
+
+variable "on_demand_min_size" {
+  default     = 1
+  description = "On Demand min size"
+}
+
+variable "on_demand_max_size" {
+  default     = 2
+  description = "On Demand max size"
 }
 
 variable "on_demand_instance_type" {
@@ -26,22 +41,61 @@ variable "on_demand_instance_type" {
   description = "On Demand Instance type"
 }
 
-variable "on_demand_max_size" {
-  default     = "2"
-  description = "On Demand Instance type"
+variable "linux_ami" {
+  default     = "ami-0e609024e4dbce4a5"
+  description = "k8s optimized EC2 AMI ID - https://amzn.to/38G1Twv"
 }
+
+variable "spot_desired_capacity" {
+  default     = 2
+  description = "Spot Desired capacity"
+}
+
+variable "spot_max_size" {
+  default     = 100
+  description = "Spot max size"
+}
+
 
 variable "spot_instance_type" {
   default     = "c5.large"
-  description = "AWS Region"
+  description = "Spot instance type"
+}
+
+variable "spot_instance_pools" {
+  default     = 2
+  description = "Number of spot instance pools"
 }
 
 variable "spot_max_price" {
   default     = "0.068"
-  description = ""
+  description = "The max price for a spot instance"
 }
 
-variable "linux_ami" {
-  default     = "ami-0e609024e4dbce4a5"
-  description = "k8s optimized EC2 AMI ID - https://amzn.to/38G1Twv"
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+}
+
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+}
+
+variable "cluster_endpoint_private_access" {
+  type        = bool
+  description = "Set the cluster endpoint to be available privately within a VPC"
+}
+
+variable "cluster_endpoint_public_access" {
+  type        = bool
+  description = "Set the cluster endpoint to be available publicly"
 }

--- a/modules/simple-log-es/main.tf
+++ b/modules/simple-log-es/main.tf
@@ -20,7 +20,7 @@ resource "aws_iam_service_linked_role" "es" {
 
 data "aws_caller_identity" "current" {}
 
-resource "aws_elasticsearch_domain" "test_w7b6" {
+resource "aws_elasticsearch_domain" "es_domain" {
   count                 = var.create_es ? 1 : 0
   domain_name           = var.es_domain
   elasticsearch_version = var.es_version
@@ -59,8 +59,6 @@ resource "aws_elasticsearch_domain" "test_w7b6" {
 }
 CONFIG
 
-  tags = {
-    Domain = "test-w7b6"
-  }
+  tags       = var.tags
   depends_on = [aws_iam_service_linked_role.es]
 }

--- a/modules/simple-log-es/outputs.tf
+++ b/modules/simple-log-es/outputs.tf
@@ -1,9 +1,9 @@
 output "es_endpoint" {
-  value       = element(concat(aws_elasticsearch_domain.test_w7b6.*.endpoint, list("")), 0)
+  value       = element(concat(aws_elasticsearch_domain.es_domain.*.endpoint, list("")), 0)
   description = "Elasticsearch API Endpoint"
 }
 
 output "es_kibana" {
-  value       = element(concat(aws_elasticsearch_domain.test_w7b6.*.kibana_endpoint, list("")), 0)
+  value       = element(concat(aws_elasticsearch_domain.es_domain.*.kibana_endpoint, list("")), 0)
   description = "Elasticsearch Kibana URL"
 }

--- a/modules/simple-log-es/variables.tf
+++ b/modules/simple-log-es/variables.tf
@@ -45,3 +45,7 @@ variable "es_instance_type" {
   default     = "t2.medium.elasticsearch"
   description = "ES Instance type to use"
 }
+
+variable "tags" {
+  description = "Tags for ES"
+}

--- a/modules/w7b6-mysql/main.tf
+++ b/modules/w7b6-mysql/main.tf
@@ -17,15 +17,15 @@ module "rds" {
 
   create_db_instance = var.create
 
-  identifier        = "w7b6"
+  identifier        = var.identifier
   engine            = "mysql"
   engine_version    = "8.0.21"
   instance_class    = var.db_instance_class
   allocated_storage = 5
   storage_encrypted = false
 
-  name     = "webhook_broker"
-  username = "webhook_broker"
+  name     = var.db_name
+  username = var.db_username
   password = var.db_password
   port     = "3306"
 
@@ -39,10 +39,7 @@ module "rds" {
   # disable backups to create DB faster
   backup_retention_period = 10
 
-  tags = {
-    Owner       = "user"
-    Environment = "dev"
-  }
+  tags = var.tags
 
   enabled_cloudwatch_logs_exports = ["error", "slowquery"]
 
@@ -56,7 +53,7 @@ module "rds" {
   major_engine_version = "8.0"
 
   # Snapshot name upon DB deletion
-  final_snapshot_identifier = "w7b6snap"
+  final_snapshot_identifier = var.final_snapshot_identifier
 
   # Database Deletion Protection
   deletion_protection = false

--- a/modules/w7b6-mysql/variables.tf
+++ b/modules/w7b6-mysql/variables.tf
@@ -3,6 +3,23 @@ variable "db_password" {
   description = "RDS MySQL password for user `webhook_broker`"
 }
 
+variable "identifier" {
+  description = "The identifier of the webhook broker"
+}
+variable "db_username" {
+  description = "Username of DB"
+}
+variable "db_name" {
+  description = "Name of the database"
+}
+variable "final_snapshot_identifier" {
+  description = "Name of final snapshot"
+}
+
+variable "tags" {
+  description = "Tags to add to db"
+}
+
 variable "subnets" {
   description = "Subnets to create the Kubernetes cluster in"
 }

--- a/modules/w7b6/main.tf
+++ b/modules/w7b6/main.tf
@@ -4,7 +4,6 @@ locals {
 
 module "mysql" {
   source                    = "../w7b6-mysql/"
-  db_password               = var.db_password
   subnets                   = var.subnets
   vpc_id                    = var.vpc_id
   create                    = var.create && var.create_rds
@@ -13,6 +12,16 @@ module "mysql" {
   db_instance_class         = var.db_instance_class
   default_security_group_id = var.default_security_group_id
   sg_cidr_blocks            = var.sg_cidr_blocks
+  identifier                = "w7b6"
+  final_snapshot_identifier = "w7b6snap"
+  db_name                   = "webhook_broker"
+  db_username               = var.db_username
+  db_password               = var.db_password
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+
 }
 
 resource "kubernetes_namespace" "webhook_broker_namespace" {

--- a/modules/w7b6/variables.tf
+++ b/modules/w7b6/variables.tf
@@ -2,6 +2,10 @@ variable "db_password" {
   default     = "zxc90zxc"
   description = "RDS MySQL password for user `webhook_broker`"
 }
+variable "db_username" {
+  default     = "webhook_broker"
+  description = "RDS MySQL username for user"
+}
 
 variable "subnets" {
   description = "Subnets to create the Kubernetes cluster in"

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,25 @@ variable "webhook_broker_hostname" {
   default     = "one.test.w7b6.net"
   description = "The DNS Entry to associate with ALB; if there is already record set `external-dns` will not override it"
 }
+
+variable "map_users" {
+  default = [
+    {
+      userarn  = "arn:aws:iam::<ACCOUNT_NUMBER>:user/<USER_NAME>"
+      username = "<USER_NAME>"
+      groups   = ["system:masters"]
+    }
+  ]
+  description = "The users mapped for the kubernetes cluster"
+}
+
+variable "map_roles" {
+  default = [
+    {
+      rolearn  = "arn:aws:iam::<ACCOUNT_NUMBER>:role/<ROLE_NAME>"
+      username = "<ROLE_NAME>"
+      groups   = ["system:masters"]
+    },
+  ]
+  description = "The roles mapped for the kubernetes cluster"
+}


### PR DESCRIPTION
## Why

To make the modules be more configurable, and removing hardcoded integrations

## How 

* Update `main.tf` with changes from modules
* Update changes in `modules/kubernetes-goodies`
    * To accept `cluster_name` as parameter in `conf/cluster-autoscaler-chart-values.yml`
    * To pass `cluster_name` as parameter in `modules/kubernetes-goodies/main.tf`
*  Update changes in  `modules/simple-kubernetes/` 
    * Extract `asg_tags` into `locals`
    * Make worker_groups parameters as variables
* Update changes in `modules/simple-log-es`
    * Change name of resource to be generic 
    * Pass tags as variables
* Update changes in `modules/w7b6-mysql` 
    * Pass username and password as variables
    * Pass db_name as variable
    * Pass identifier and snapshot_identifier as variables
* Update `modules/w7b6`  with changes from modules

## Test
Running `terraform plan` should not result in errors and if existing infra exists, there should be 0 infrastructure changes.