### PR TITLE
Optimize mysql parameter group

### DIFF
--- a/modules/w7b6-mysql/main.tf
+++ b/modules/w7b6-mysql/main.tf
@@ -66,6 +66,10 @@ module "rds" {
     {
       name  = "character_set_server"
       value = "utf8"
+    },
+    {
+      name  = "transaction_isolation"
+      value = "READ-COMMITTED"
     }
   ]
 

--- a/modules/w7b6-mysql/main.tf
+++ b/modules/w7b6-mysql/main.tf
@@ -70,6 +70,11 @@ module "rds" {
     {
       name  = "transaction_isolation"
       value = "READ-COMMITTED"
+    },
+    {
+      name  = "innodb_dedicated_server"
+      value = "ON"
+      apply_method = "pending-reboot"
     }
   ]
 

--- a/modules/w7b6-mysql/main.tf
+++ b/modules/w7b6-mysql/main.tf
@@ -61,11 +61,11 @@ module "rds" {
   parameters = [
     {
       name  = "character_set_client"
-      value = "utf8"
+      value = "utf8mb4"
     },
     {
       name  = "character_set_server"
-      value = "utf8"
+      value = "utf8mb4"
     },
     {
       name  = "transaction_isolation"

--- a/modules/w7b6/variables.tf
+++ b/modules/w7b6/variables.tf
@@ -85,6 +85,6 @@ variable "db_url_override" {
 }
 
 variable "w7b6_chart_version" {
-  default     = "0.1.0-beta-2"
+  default     = "0.1.0"
   description = "Custom Webhook Broker Chart configuration which will override the default chart config"
 }


### PR DESCRIPTION
Set [`transaction_isolation` ](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html#isolevel_read-committed) to `READ-COMMITTED`, and enable optmized innodb parameters by setting [`innodb_dedicated_server`](https://dev.mysql.com/doc/refman/8.0/en/innodb-dedicated-server.html) to `ON`.

Also set character set to `utf8mb4`, which enables using full range of unicode characters (`utf8mb4` was made default in MySQL 8.0, so we could omit this from the declared parameters as well).
